### PR TITLE
Add flake8 support to tox

### DIFF
--- a/aetherscale/api/broker.py
+++ b/aetherscale/api/broker.py
@@ -128,7 +128,7 @@ def run():
 
     handler = ComputingHandler(radvd, service_manager)
 
-    bound_callback = lambda ch, method, properties, body: \
+    def bound_callback(ch, method, properties, body):
         callback(ch, method, properties, body, handler)
     channel.basic_consume(
         queue=exclusive_queue_name, on_message_callback=bound_callback)

--- a/aetherscale/execution.py
+++ b/aetherscale/execution.py
@@ -12,5 +12,3 @@ def run_command_chain(commands: Iterator[List[str]]) -> bool:
             return False
 
     return True
-
-

--- a/aetherscale/qemu/image.py
+++ b/aetherscale/qemu/image.py
@@ -37,7 +37,7 @@ def guestmount(image_path: Path) -> Iterator[Path]:
         # thus we have to wait until write-lock is released, but at most k
         # seconds
         with aetherscale.timing.timeout(seconds=5):
-            logging.debug(f'Waiting for write lock to get released')
+            logging.debug('Waiting for write lock to get released')
 
             access_ok = False
             while not access_ok:
@@ -53,7 +53,7 @@ def install_startup_script(script_source: str, mount_dir: Path):
         create_systemd_startup_unit(f, Path(f'/root/{STARTUP_FILENAME}.sh'))
 
     multi_user_target_path = \
-        mount_dir / f'etc/systemd/system/multi-user.target.wants'
+        mount_dir / 'etc/systemd/system/multi-user.target.wants'
     multi_user_target_path.mkdir(parents=True, exist_ok=True)
 
     with tempfile.NamedTemporaryFile('wt') as startup_script:

--- a/tests/test_qemu.py
+++ b/tests/test_qemu.py
@@ -89,7 +89,7 @@ def test_timeout(timeout):
     # because it expects to receive a welcome capabilities message from the
     # server
 
-    with run_mock_qemu_server(str(sock_file), QemuProtocol.QGA) as mock_server:
+    with run_mock_qemu_server(str(sock_file), QemuProtocol.QGA) as mock_server:  # noqa: F841
         with timeout(1):  # if function does not finish after 1s, error-out
             with pytest.raises(socket.timeout):
                 QemuMonitor(sock_file, QemuProtocol.QMP, timeout=0.1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean,py3,report
+envlist = clean,py3,flake8,report
 
 [testenv]
 deps =
@@ -7,6 +7,14 @@ deps =
     pytest
 commands =
     coverage run --source aetherscale -m pytest
+
+[testenv:flake8]
+skip_install = true
+deps =
+    flake8
+    flake8-bugbear
+commands =
+    flake8 tests aetherscale
 
 [testenv:clean]
 deps = coverage
@@ -17,3 +25,6 @@ commands = coverage erase
 commands =
     coverage report
     coverage html
+
+[flake8]
+max-line-length = 100


### PR DESCRIPTION
Flake8 is a useful static analyzer. This patch series adds it to tox.ini and fixes the fallout.